### PR TITLE
fixing model_data.phylolm column error

### DIFF
--- a/.Rhistory
+++ b/.Rhistory
@@ -1,10 +1,3 @@
-<<<<<<< HEAD
-devtools::load_all(".")
-knitr::opts_chunk$set(echo = TRUE)
-library(ape)
-library(geiger)
-library(OUwie)
-library(tidyverse)
 arbutus::arbutus(sim_fit)
 arbutus::arbutus(sim_fit)
 arbutus::arbutus(sim_fit)

--- a/R/internal-phylolm.R
+++ b/R/internal-phylolm.R
@@ -17,7 +17,7 @@ model_type.phylolm <- function(fit, ...){
 model_data.phylolm <- function(fit, phy, ...){
     if (missing(phy))
       stop("phylolm fitted objects do not include the phylogeny. This needs to be entered separately with the argument 'phy'.")
-    res <- fit$residuals[,1]
+    res <- fit$residuals
     list(phy=phy, data=res)
 }
 


### PR DESCRIPTION
model_data.phylolm is not working for phylolm because it is getting residuals from fit$residuals[ ,1]. However,  fit$residuals is a vectors. Now, residuals are returned from fit$residuals. 